### PR TITLE
fix: add benny smith as author and link to github

### DIFF
--- a/riddc/notebooks/fox-kemper/sea_surface_height.ipynb
+++ b/riddc/notebooks/fox-kemper/sea_surface_height.ipynb
@@ -9,6 +9,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Author of this document: Benny Smith <a href=\"https://github.com/austinbennysmith\"><img width=\"75\" height=\"25\" style=\"vertical-align:middle;\" src=\"https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white\"></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "LRdamHBuZf_E"

--- a/riddc/notebooks/fox-kemper/ultra_high_res_sst.ipynb
+++ b/riddc/notebooks/fox-kemper/ultra_high_res_sst.ipynb
@@ -9,6 +9,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Author of this document: Benny Smith <a href=\"https://github.com/austinbennysmith\"><img width=\"75\" height=\"25\" style=\"vertical-align:middle;\" src=\"https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white\"></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "mWg9LA1sVLDF"


### PR DESCRIPTION
This pull request adds author attribution to two Jupyter notebooks by including a markdown cell with the author's name and GitHub profile link.

Documentation updates:

* Added a markdown cell at the top of `sea_surface_height.ipynb` identifying Benny Smith as the author and linking to his GitHub profile.
* Added a similar author attribution markdown cell to `ultra_high_res_sst.ipynb`.